### PR TITLE
Fix indentation issue in replace_pronouns method

### DIFF
--- a/anonymizer.py
+++ b/anonymizer.py
@@ -106,7 +106,7 @@ class Anonymizer:
 
         return anon_input_seq
 
-        def replace_pronouns(self, anon_input_seq):
+    def replace_pronouns(self, anon_input_seq):
         # https://blog.hubspot.com/marketing/gender-neutral-pronouns
         pronoun_map = {
             "he": "PRONOUN",


### PR DESCRIPTION
Fix for:

```
$ python3 anon.py --language en --input_dir examples --output_dir anonymised_examples --cpu
Traceback (most recent call last):
  File "anon.py", line 5, in <module>
    from anonymizer import Anonymizer
  File "/home/juha/raid/github/textwash/anonymizer.py", line 111
    pronoun_map = {
              ^
IndentationError: expected an indented block
```