### PR TITLE
Fix URL replacement bug in anonymize function

### DIFF
--- a/anonymizer.py
+++ b/anonymizer.py
@@ -234,7 +234,7 @@ class Anonymizer:
         anon_input_seq = re.sub("https*://\S+", "URL", orig_input_seq)
 
         anon_input_seq = self.replace_identified_entities(
-            entities, orig_input_seq, entity2generic
+            entities, anon_input_seq, entity2generic
         )
 
         anon_input_seq = self.replace_numerics(anon_input_seq)


### PR DESCRIPTION
- `anonymize` does URL scrubbing prior to named entity replacement
- pass updated `anon_input_seq` to entity replacement so URLs actually get replaced as intended

------
https://chatgpt.com/codex/tasks/task_e_683fe58a5820832b8a621e9500b413e6