### PR TITLE
Unpin torch and transformers to support Python 3.10+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 .vscode
 data/model.pth
 venv/
+
+data/en/
+data/nl/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have a tool that meets these requirements, we would be glad to promote it
 
 Textwash is built in Python3. To run the software, it is recommended to first create an Anaconda environment and install the required dependencies. For details on how to get and install Anaconda, click [here](https://www.anaconda.com/products/distribution).
 
-    $ conda create -n textwash python=3.7
+    $ conda create -n textwash python=3.9
     $ conda activate textwash
     $ pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-torch==1.9.0
-transformers==4.28.1
+torch>=2.0.0
+transformers>=4.40.0


### PR DESCRIPTION
torch==1.9.0 has no wheels for Python 3.10+ and cannot be built from source on modern toolchains (Debian Trixie, Ubuntu 24.04). The code only uses stable, long-standing API surface (torch.device, AutoTokenizer, AutoModelForTokenClassification, pipeline) that is fully compatible with current releases.

- torch>=2.0.0 (tested: 2.10.0+cpu)
- transformers>=4.40.0 (tested: 5.2.0)
- add data/en/ and data/nl/ to .gitignore (downloaded models, not for VCS)